### PR TITLE
Added boundary check to back() to counter access violation when _size==0

### DIFF
--- a/src/Vector/VectorDefinitions.h
+++ b/src/Vector/VectorDefinitions.h
@@ -81,7 +81,7 @@ T & Vector<T>::front()
 template <typename T>
 T & Vector<T>::back()
 {
-  return values_[size_-1];
+  return (size_ > 0) ? values_[size_-1] : values_[0];
 }
 
 template <typename T>


### PR DESCRIPTION
Calling back() when vector has size_==0 will lead to segfault because back() returns object with size_ - 1 as index.